### PR TITLE
리팩터: BanPickResponseDto 생성 및 DTO 매핑 개선

### DIFF
--- a/src/main/java/com/lol/fearlessdraft/controller/BanPickController.java
+++ b/src/main/java/com/lol/fearlessdraft/controller/BanPickController.java
@@ -3,16 +3,16 @@ package com.lol.fearlessdraft.controller;
 
 import com.lol.fearlessdraft.dto.banpick.BanPickMessage;
 import com.lol.fearlessdraft.dto.banpick.BanPickResponseDto;
-import com.lol.fearlessdraft.entity.BanPickActionType;
+
 import com.lol.fearlessdraft.service.BanPickService;
-import com.lol.fearlessdraft.service.GameService;
+
 
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
+
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,12 +22,11 @@ import java.util.List;
 @RequestMapping("/api/banpick")
 public class BanPickController {
 
-    private final GameService gameService;
+
     private final BanPickService banPickService;
     private final SimpMessagingTemplate messagingTemplate;
-    public BanPickController(GameService gameService, BanPickService banPickService, SimpMessagingTemplate messagingTemplate) {
+    public BanPickController( BanPickService banPickService, SimpMessagingTemplate messagingTemplate) {
 
-        this.gameService = gameService;
         this.banPickService = banPickService;
         this.messagingTemplate = messagingTemplate;
     }

--- a/src/main/java/com/lol/fearlessdraft/dto/banpick/BanPickResponseDto.java
+++ b/src/main/java/com/lol/fearlessdraft/dto/banpick/BanPickResponseDto.java
@@ -2,13 +2,27 @@ package com.lol.fearlessdraft.dto.banpick;
 
 import com.lol.fearlessdraft.entity.BanPickActionType;
 
+import com.lol.fearlessdraft.entity.PickBan;
 import lombok.Builder;
 
-@Builder
+
 public record BanPickResponseDto(
         Long teamId,
         String teamName,
         String championName,
         BanPickActionType actionType,
         int turnOrder
-) {}
+) {
+    public static  BanPickResponseDto of( PickBan pickBan ) {
+     return  new BanPickResponseDto(pickBan.getId(),
+                                    pickBan.getTeam().getTeamName(),
+                                    pickBan.getChampionName(),
+                                    pickBan.getType(),
+                                   pickBan.getTurnOrder()
+
+     ) ;
+    }
+
+
+
+}

--- a/src/main/java/com/lol/fearlessdraft/dto/match/MatchResponseDto.java
+++ b/src/main/java/com/lol/fearlessdraft/dto/match/MatchResponseDto.java
@@ -1,9 +1,10 @@
 package com.lol.fearlessdraft.dto.match;
 
+import com.lol.fearlessdraft.entity.Match;
 import com.lol.fearlessdraft.entity.MatchType;
-import lombok.Builder;
 
-@Builder
+
+
 public record MatchResponseDto(
     Long matchId,
     String matchName,
@@ -14,4 +15,15 @@ public record MatchResponseDto(
     boolean allowSpectators
 
 ) {
+    public static MatchResponseDto from(Match match) {
+        return new MatchResponseDto(
+                match.getId(),
+                match.getMatchName(),
+                match.getNumberOfGames(),
+                match.getTeamA().getTeamName(),
+                match.getTeamB().getTeamName(),
+                match.getMatchType(),
+                match.isAllowSpectators()
+        );
+    }
 }

--- a/src/main/java/com/lol/fearlessdraft/service/BanPickService.java
+++ b/src/main/java/com/lol/fearlessdraft/service/BanPickService.java
@@ -114,18 +114,13 @@ public class BanPickService {
         }
     }
 
-    @Transactional(readOnly = true)
+        @Transactional(readOnly = true)
     public List<BanPickResponseDto> getBanPickHistoryByGame(Game game) {
         return pickBanRepository.findAllByGameOrderByTurnOrderAsc(game)
                 .stream()
-                .map(pick -> BanPickResponseDto.builder()
-                        .teamId(pick.getTeam().getId())
-                        .teamName(pick.getTeam().getTeamName())
-                        .championName(pick.getChampionName())
-                        .actionType(pick.getType())
-                        .turnOrder(pick.getTurnOrder())
-                        .build()
-                ).toList();
+                .map(BanPickResponseDto::of
+                )
+                .toList();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- `BanPickResponseDto.of(PickBan pickBan)` 정적 팩토리 메서드 추가로 DTO 생성 로직 캡슐화
- `getBanPickHistoryByGame` 메서드를 `BanPickResponseDto::of` 사용하도록 리팩터링하여 코드 간결화